### PR TITLE
DEXA-370 - replaced interfaces and classes with models and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ allows sharing videos during a conference.
 
 ## SDK 3.3 License agreement
 
-Before using the latest version of the @dolbyio/react-native-comms-sdk, please review and accept the [Dolby Software License Agreement](https://github.com/voxeet/voxeet-sdk-android/blob/main/LICENSE).
+Before using the latest version of the @dolbyio/react-native-comms-sdk, please review and accept the [Dolby Software License Agreement](./LICENSE).
 
 ## Third Party licenses
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pods": "cd example/ios && pod install",
     "pods:x86_64": "cd example/ios && arch -x86_64 pod install",
     "bootstrap": "yarn example && yarn && yarn pods",
-    "documentation": "rm -rf docs && typedoc --disableSources",
+    "documentation": "rm -rf docs && typedoc --disableSources --sort source-order",
     "documentation:convert": "yarn documentation && rm -rf scripts/docs && cd scripts && node convertDocs.js",
     "documentation:append": "git add docs",
     "license": "yarn npm-license-crawler --production --start ./ --json ./LICENSES.json --exclude ./example --onlyDirectDependencies"

--- a/scripts/convertDocs.js
+++ b/scripts/convertDocs.js
@@ -1,6 +1,47 @@
 const fs = require('fs');
 const path = require('path');
 
+/** SUMMARY:
+ * This summary should help someone who stumbles upon this file to understand
+ * what and why we're changing.
+ *
+ * It is an internal Dolby requirement for documentation files to have a specific
+ * structure and contents. Quite a lot of things that typedoc library generates
+ * from our typescript files unfortunately doesn't match Dolby requirements. This file
+ * serves as a documentation-compatibility generator that takes originally created
+ * documentation files and convert their contents and their names.
+ * Running the script requires original documentation files to be present in root
+ * `/docs` directory. Newly created files will appear in /scripts/docs directory.
+ *
+ *
+ * KNOWN REQUIREMENTS as of 11.01.2022
+ * 1. Documentation Files need to have a header for SEO and CI/CD purposes - this is
+ * done with createDocHeader() function.
+ *
+ * 2. Documentation Files need to have their slug generated based on their names. This
+ * follows a convention of slugprefix-module-filename e.g.
+ * rn-client-sdk-references-videopresentationservice. This is done with createHeaderSlug(filePath)
+ * function.
+ *
+ * 3. Documentation Files need to have their internal links swapped. Originally we have
+ * links in a format of [`Conference`](../interfaces/internal.Conference.md) - requirement
+ * is to get rid of backticks in [`Conference`] and change link path from ../interfaces/internal.Conference.md
+ * to doc:rn-client-sdk-interfaces-conference - full change should look like:
+ * [Conference](doc:rn-client-sdk-models-conference) (this is already with module
+ * rename from point 4.)
+ *
+ * 4. Documentation Files need to have their module folder names renamed:
+ * interfaces => models
+ * classes => references
+ * This change also includes changes in link paths inside the files and slug names.
+ *
+ * 5. Documentation Files need to have their Table of contents removed. Starting with
+ * the title and following contents beneath (up until major category title e.g.
+ * ## Properties or ## Methods or ## Enumeration members).
+ * One exception is CommsAPI file that should also have its Table of contents removed
+ * but without ## Properties part.
+ */
+
 /**
  * This will match and capture raw documentation filenames (ignoring any prefixes)
  * e.g. it will match `internal.ConferenceService.md` and capture `ConferenceService`
@@ -22,9 +63,14 @@ const REGEXP_MATCH_DOC_MODULE = /docs\/(\w+)\//;
 
 const REGEXP_MATCH_INTERNAL_LINKS = /\[internal].+/g;
 const REGEXP_MATCH_CLASS_TITLES = /# Class: \w+/g;
+const REGEXP_MATCH_DOC_TITLES = /(# Interface:|# Enumeration:|# Namespace:).+/g;
 const REGEXP_MATCH_TABLE_OF_CONTENTS =
-  /(## Table of contents[\S\s*]*)(?=## Methods|## Properties)/g;
+  /(## Table of contents[\S\s*]*)(?=## Properties|## Methods|## Enumeration members)/g;
 
+const REGEXP_MATCH_TABLE_OF_CONTENTS_COMMS_FILE =
+  /(## Table of contents[\S\s*]*)(?=## Properties)/g;
+
+const REGEXP_MATCH_EVENT_HANDLERS = /(### on[\S\s*]*)/g;
 /**
  * This will match and capture all full link descriptions
  * e.g. it will capture `Participant` and Participant from [`Participant`](../interfaces/internal.Participant.md)
@@ -103,13 +149,17 @@ metadata:
 function convertDoc(filePath, index) {
   let renamedFilepath = filePath;
 
+  /** one of requirements is to rename `interfaces` => `models`
+   * and `classes` => `references` do suit dolby documentation naming convention */
   if (/classes/.test(renamedFilepath)) {
     renamedFilepath = renamedFilepath.replace(/classes/, 'references');
   } else if (/interfaces/.test(renamedFilepath)) {
     renamedFilepath = renamedFilepath.replace(/interfaces/, 'models');
   }
+
   let moduleName = getFilePathModuleName(renamedFilepath);
 
+  /** we make sure our file has `internal.MyService` in its name */
   if (isInternalDocFile(renamedFilepath) && moduleName) {
     const rawFileName = filePath.match(REGEXP_MATCH_DOC_FILENAME);
     if (!rawFileName) {
@@ -117,8 +167,10 @@ function convertDoc(filePath, index) {
     }
     const slug = createHeaderSlug(renamedFilepath);
     const header = createDocHeader(rawFileName[1], slug, index);
-    // we use substring to create new path; here we're going from
-    // ../docs/interface/.. to ./docs/interface/..
+
+    /** we use substring to create new path; here we're going from
+    ../docs/interface/.. to ./docs/interface/.. -- we also rename our files to
+     slugnames since it's also part of requirement */
     const newFilePath = path.dirname(renamedFilepath).substring(1);
     const newFileName = newFilePath + `/${slug}.md`;
 
@@ -128,22 +180,35 @@ function convertDoc(filePath, index) {
     }
     const docAsString = fileBuffer.toString();
     const docWithHeader = header + docAsString;
-    const convertedDocAsString = docWithHeader
+    let convertedDocAsString = '';
+    convertedDocAsString = docWithHeader
       .replaceAll(REGEXP_MATCH_DOC_LINKS, (substring) =>
         changeLinkFormatReplacerFn(substring, moduleName)
       )
       .replaceAll(REGEXP_MATCH_INTERNAL_LINKS, '')
       .replaceAll(REGEXP_MATCH_CLASS_TITLES, '')
-      .replaceAll(REGEXP_MATCH_TABLE_OF_CONTENTS, '')
-      .replaceAll(
-        REGEXP_MATCH_BACKTICKS,
-        (substring, captureGroupOne, captureGroupTwo) => {
-          return substring.replace(
-            /(?<=\[)(`(\w+)`)(?=]\(.+\))/,
-            captureGroupTwo
-          );
-        }
+      .replaceAll(REGEXP_MATCH_DOC_TITLES, '')
+      .replaceAll(REGEXP_MATCH_BACKTICKS, (substring, _, captureGroupTwo) => {
+        return substring.replace(
+          /(?<=\[)(`(\w+)`)(?=]\(.+\))/,
+          captureGroupTwo
+        );
+      })
+      .replaceAll(REGEXP_MATCH_EVENT_HANDLERS, (substring, captureGroup) => {
+        return `## Event handlers\n\n${substring}`;
+      });
+    if (rawFileName[1] === 'CommsAPI') {
+      convertedDocAsString = convertedDocAsString.replaceAll(
+        REGEXP_MATCH_TABLE_OF_CONTENTS_COMMS_FILE,
+        ''
       );
+    } else {
+      convertedDocAsString = convertedDocAsString.replaceAll(
+        REGEXP_MATCH_TABLE_OF_CONTENTS,
+        ''
+      );
+    }
+
     try {
       if (!fs.existsSync(newFilePath)) {
         fs.mkdirSync(newFilePath, {
@@ -177,17 +242,17 @@ function buildFilesPathArray(dir) {
 
 /**
  * This function ensures that whatever file we're reading and changing, has `internal`
- * in its path (then it means it's DolbyIoSDK module)
+ * in its path (then it means it's Dolby documentation file)
  */
 function isInternalDocFile(filepath) {
   return !!new RegExp(REGEXP_MATCH_DOC_FILENAME).test(filepath);
 }
 
 /**
- * This function creates header slug (format slug prefix + module + filename in lowercase)
+ * This function creates header slug (format: slug prefix + module + filename in lowercase)
  * e.g. slug for a file `../docs/interfaces/internal.ConferenceMixingOptions.md` should look like
  * `rn-client-sdk-interfaces-conferencemixingoptions`
- * NOTE: at this point we assume filepath is correct (isInternalDocFile function should return true)
+ * NOTE: at this point we assume filepath have internal.MyService filename format
  */
 function createHeaderSlug(filePath) {
   const sdkModule = filePath.match(REGEXP_MATCH_DOC_MODULE)[1];

--- a/scripts/convertDocs.js
+++ b/scripts/convertDocs.js
@@ -20,11 +20,10 @@ const REGEXP_MATCH_DOC_LINKS = /\[.+?]\((.+?\.md)(?:#.+?)?\)/g;
  */
 const REGEXP_MATCH_DOC_MODULE = /docs\/(\w+)\//;
 
-const REGEXP_MATCH_CONSTRUCTOR_HEADER = /###? Constructors?/gi;
-const REGEXP_MATCH_CONSTRUCTOR_LINK = /- \[constructor].+/g;
-const REGEXP_MATCH_CONSTRUCTOR_INIT = /• \*\*new.+/g;
 const REGEXP_MATCH_INTERNAL_LINKS = /\[internal].+/g;
 const REGEXP_MATCH_CLASS_TITLES = /# Class: \w+/g;
+const REGEXP_MATCH_TABLE_OF_CONTENTS =
+  /(## Table of contents[\S\s*]*)(?=## Methods|## Properties)/g;
 
 /**
  * This will match and capture all full link descriptions
@@ -133,11 +132,9 @@ function convertDoc(filePath, index) {
       .replaceAll(REGEXP_MATCH_DOC_LINKS, (substring) =>
         changeLinkFormatReplacerFn(substring, moduleName)
       )
-      .replaceAll(REGEXP_MATCH_CONSTRUCTOR_HEADER, '')
-      .replaceAll(REGEXP_MATCH_CONSTRUCTOR_LINK, '')
-      .replaceAll(REGEXP_MATCH_CONSTRUCTOR_INIT, '')
       .replaceAll(REGEXP_MATCH_INTERNAL_LINKS, '')
       .replaceAll(REGEXP_MATCH_CLASS_TITLES, '')
+      .replaceAll(REGEXP_MATCH_TABLE_OF_CONTENTS, '')
       .replaceAll(
         REGEXP_MATCH_BACKTICKS,
         (substring, captureGroupOne, captureGroupTwo) => {

--- a/scripts/convertDocs.js
+++ b/scripts/convertDocs.js
@@ -166,7 +166,11 @@ function convertDoc(filePath, index) {
       throw new Error(`[${renamedFilepath}]: reading raw filename error`);
     }
     const slug = createHeaderSlug(renamedFilepath);
-    const header = createDocHeader(rawFileName[1], slug, index);
+    const header = createDocHeader(
+      rawFileName[1] === 'internal' ? 'modules' : rawFileName[1],
+      slug,
+      index
+    );
 
     /** we use substring to create new path; here we're going from
     ../docs/interface/.. to ./docs/interface/.. -- we also rename our files to
@@ -257,7 +261,11 @@ function isInternalDocFile(filepath) {
 function createHeaderSlug(filePath) {
   const sdkModule = filePath.match(REGEXP_MATCH_DOC_MODULE)[1];
   const rawFilename = filePath.match(REGEXP_MATCH_DOC_FILENAME)[1];
-  return SLUG_PREFIX + sdkModule + `-${rawFilename.toLowerCase()}`;
+  return (
+    SLUG_PREFIX +
+    sdkModule +
+    (sdkModule === 'modules' ? '' : `-${rawFilename.toLowerCase()}`)
+  );
 }
 
 /**
@@ -276,7 +284,7 @@ function changeLinkFormatReplacerFn(substring, moduleName) {
   let replaceString;
   const isRootInternalModule = new RegExp('internal.md').test(substring);
   if (isRootInternalModule) {
-    replaceString = LINK_SLUG_PREFIX + 'modules-internal';
+    replaceString = LINK_SLUG_PREFIX + 'modules';
     return substring.replace(/(?<=\[.+]\().+\.md(?=(#.+)?\))/, replaceString);
   }
   const module = substring

--- a/src/services/conference/ConferenceService.ts
+++ b/src/services/conference/ConferenceService.ts
@@ -48,14 +48,6 @@ export class ConferenceService {
   }
 
   /**
-   * Returns a Conference object that can be used to join the conference. If the conference ID is not provided, the method returns the current Conference object.
-   * @param conferenceId The conference ID.
-   */
-  public async fetch(conferenceId?: string): Promise<Conference> {
-    return transformToConference(await this._nativeModule.fetch(conferenceId));
-  }
-
-  /**
    * Returns the Conference object for the current conference.
    */
   public async current(): Promise<Conference> {
@@ -63,20 +55,11 @@ export class ConferenceService {
   }
 
   /**
-   * Replays a previously recorded conference. For more information, see the [Recording mechanisms](doc:guides-recording-mechanisms) article.
-   * @param conference The Conference object.
-   * @param replayOptions The replay options.
+   * Returns a Conference object that can be used to join the conference. If the conference ID is not provided, the method returns the current Conference object.
+   * @param conferenceId The conference ID.
    */
-  public async replay(
-    conference: Conference,
-    replayOptions?: ConferenceReplayOptions
-  ): Promise<Conference> {
-    return transformToConference(
-      await this._nativeModule.replay(conference, {
-        offset: 0,
-        ...replayOptions,
-      })
-    );
+  public async fetch(conferenceId?: string): Promise<Conference> {
+    return transformToConference(await this._nativeModule.fetch(conferenceId));
   }
 
   /**
@@ -146,90 +129,6 @@ export class ConferenceService {
   }
 
   /**
-   * Enables and disables audio processing for a conference participant.
-   * @param options The AudioProcessingOptions model includes the AudioProcessingSenderOptions model responsible for enabling and disabling audio processing.
-   */
-  public async setAudioProcessing(
-    options: AudioProcessingOptions = {}
-  ): Promise<void> {
-    return this._nativeModule.setAudioProcessing(options);
-  }
-
-  /**
-   * Sets the maximum number of video streams that may be transmitted to the local participant.
-   * @param max The maximum number of video streams that may be transmitted to the local participant. The valid parameter values are between 0 and 4. By default, the parameter is set to 4.
-   * @param prioritizedParticipants The list of the prioritized participants. This parameter allows using a pin option to prioritize specific participant's video streams and display their videos even when these participants do not talk.
-   */
-  public async setMaxVideoForwarding(
-    max: MaxVideoForwarding = 4,
-    prioritizedParticipants: Participant[] = []
-  ): Promise<any> {
-    return this._nativeModule.setMaxVideoForwarding(
-      max,
-      prioritizedParticipants
-    );
-  }
-
-  /**
-   * Stops playing the specified remote participants' audio to the local participant or stops playing the local participant's audio to the conference.
-   * @param isMuted The mute state, `true` indicates that a participant is muted, `false` indicates that a participant is not muted.
-   * @param participant A remote participant.
-   */
-  public async mute(
-    participant: Participant,
-    isMuted: boolean
-  ): Promise<boolean> {
-    return this._nativeModule.mute(participant, isMuted);
-  }
-
-  /**
-   * Updates the participant's conference permissions.
-   * @param participantPermissions The set of participant's conference permissions.
-   */
-  public async updatePermissions(
-    participantPermissions: Array<ParticipantPermissions>
-  ): Promise<void> {
-    return this._nativeModule.updatePermissions(participantPermissions);
-  }
-
-  /**
-   * Starts audio transmission between the local client and a conference. The startAudio method impacts only the audio streams that the local participant sends and receives; the method does not impact the audio transmission between remote participants and a conference and does not allow the local participant to force sending remote participants’ streams to the conference or to the local participant. Depending on the specified participant in the `participant` parameter, the startAudio method starts the proper audio transmission:
-   * - When the specified participant is the local participant, startAudio ensures sending local participant’s audio from the local client to the conference.
-   * - When the specified participant is a remote participant, startAudio ensures sending remote participant’s audio from the conference to the local client. This allows the local participant to unmute remote participants who are locally muted through the [stopAudio](#stopaudio) method.
-   * @param participant The selected participant. If you wish to transmit the local participant's audio stream to the conference, provide the local participant's object. If you wish to receive the specific remote participants' audio streams, provide these remote participants' objects.
-   */
-
-  public async startAudio(participant: Participant): Promise<void> {
-    return this._nativeModule.startAudio(participant);
-  }
-
-  /**
-   * Notifies the server to either start sending the local participant's video stream to the conference or start sending a remote participant's video stream to the local participant. The startVideo method does not control the remote participant's video stream; if a remote participant does not transmit any video stream, the local participant cannot change it using the startVideo method.
-   * @param participant The participant who will receive the video stream, either remote or local.
-   */
-  public async startVideo(participant: Participant): Promise<void> {
-    return this._nativeModule.startVideo(participant);
-  }
-
-  /**
-   * Stops audio transmission between the local client and a conference. The stopAudio method impacts only the audio streams that the local participant sends and receives; the method does not impact the audio transmission between remote participants and a conference and does not allow the local participant to stop sending remote participants’ streams to the conference. Depending on the specified participant in the `participant` parameter, the stopAudio method stops the proper audio transmission:
-   * - When the specified participant is the local participant, stopAudio stops sending local participant’s audio from the local client to the conference.
-   * - When the specified participant is a remote participant, stopAudio stops sending remote participant’s audio from the conference to the local client. This allows the local participant to locally mute remote participants.
-   * @param participant The selected participant. If you wish to not transmit the local participant's audio stream to the conference, provide the local participant's object. If you wish to not receive the specific remote participants' audio streams, provide these remote participants' objects.
-   */
-  public async stopAudio(participant: Participant): Promise<void> {
-    return this._nativeModule.stopAudio(participant);
-  }
-
-  /**
-   * Notifies the server to either stop sending the local participant's video stream to the conference or stop sending a remote participant's video stream to the local participant.
-   * @param participant The participant who wants to stop receiving a video stream.
-   */
-  public async stopVideo(participant: Participant): Promise<void> {
-    return this._nativeModule.stopVideo(participant);
-  }
-
-  /**
    * Joins a conference and returns the Conference object.
    * @param conference The Conference object.
    * @param options The additional options for the joining participant.
@@ -263,6 +162,127 @@ export class ConferenceService {
     } else {
       return;
     }
+  }
+
+  /**
+   * Stops playing the specified remote participants' audio to the local participant or stops playing the local participant's audio to the conference.
+   * @param isMuted The mute state, `true` indicates that a participant is muted, `false` indicates that a participant is not muted.
+   * @param participant A remote participant.
+   */
+  public async mute(
+    participant: Participant,
+    isMuted: boolean
+  ): Promise<boolean> {
+    return this._nativeModule.mute(participant, isMuted);
+  }
+
+  /**
+   * Replays a previously recorded conference. For more information, see the [Recording mechanisms](doc:guides-recording-mechanisms) article.
+   * @param conference The Conference object.
+   * @param replayOptions The replay options.
+   */
+  public async replay(
+    conference: Conference,
+    replayOptions?: ConferenceReplayOptions
+  ): Promise<Conference> {
+    return transformToConference(
+      await this._nativeModule.replay(conference, {
+        offset: 0,
+        ...replayOptions,
+      })
+    );
+  }
+
+  /**
+   * Enables and disables audio processing for a conference participant.
+   * @param options The AudioProcessingOptions model includes the AudioProcessingSenderOptions model responsible for enabling and disabling audio processing.
+   */
+  public async setAudioProcessing(
+    options: AudioProcessingOptions = {}
+  ): Promise<void> {
+    return this._nativeModule.setAudioProcessing(options);
+  }
+
+  /**
+   * Sets the maximum number of video streams that may be transmitted to the local participant.
+   * @param max The maximum number of video streams that may be transmitted to the local participant. The valid parameter values are between 0 and 4. By default, the parameter is set to 4.
+   * @param prioritizedParticipants The list of the prioritized participants. This parameter allows using a pin option to prioritize specific participant's video streams and display their videos even when these participants do not talk.
+   */
+  public async setMaxVideoForwarding(
+    max: MaxVideoForwarding = 4,
+    prioritizedParticipants: Participant[] = []
+  ): Promise<any> {
+    return this._nativeModule.setMaxVideoForwarding(
+      max,
+      prioritizedParticipants
+    );
+  }
+
+  /**
+   * Starts audio transmission between the local client and a conference. The startAudio method impacts only the audio streams that the local participant sends and receives; the method does not impact the audio transmission between remote participants and a conference and does not allow the local participant to force sending remote participants’ streams to the conference or to the local participant. Depending on the specified participant in the `participant` parameter, the startAudio method starts the proper audio transmission:
+   * - When the specified participant is the local participant, startAudio ensures sending local participant’s audio from the local client to the conference.
+   * - When the specified participant is a remote participant, startAudio ensures sending remote participant’s audio from the conference to the local client. This allows the local participant to unmute remote participants who are locally muted through the [stopAudio](#stopaudio) method.
+   * @param participant The selected participant. If you wish to transmit the local participant's audio stream to the conference, provide the local participant's object. If you wish to receive the specific remote participants' audio streams, provide these remote participants' objects.
+   */
+  public async startAudio(participant: Participant): Promise<void> {
+    return this._nativeModule.startAudio(participant);
+  }
+
+  /**
+   * Starts a screen sharing session.
+   * The ScreenShare with iOS document (https://docs.dolby.io/communications-apis/docs/screenshare-with-ios) describes how to set up screen-share outside the application.
+   * Instead of setting the following properties:
+   * - CommsSDK.shared.appGroup = "YOUR_APP_GROUP"
+   * - CommsSDK.shared.preferredExtension = "YOUR_BROADCAST_EXTENSION_BUNDLE_ID"
+   *  Set up keys in your `Info.plist` file:
+   * - Add a new `DolbyioSdkAppGroupKey` as a string type and enter the group name ("YOUR_APP_GROUP").
+   * - Add a new `DolbyioSdkPreferredExtensionKey` as a string type and enter the broadcast extension bundle ID ("YOUR_BROADCAST_EXTENSION_BUNDLE_ID").
+   */
+  public async startScreenShare(): Promise<void> {
+    return this._nativeModule.startScreenShare();
+  }
+
+  /**
+   * Notifies the server to either start sending the local participant's video stream to the conference or start sending a remote participant's video stream to the local participant. The startVideo method does not control the remote participant's video stream; if a remote participant does not transmit any video stream, the local participant cannot change it using the startVideo method.
+   * @param participant The participant who will receive the video stream, either remote or local.
+   */
+  public async startVideo(participant: Participant): Promise<void> {
+    return this._nativeModule.startVideo(participant);
+  }
+
+  /**
+   * Stops audio transmission between the local client and a conference. The stopAudio method impacts only the audio streams that the local participant sends and receives; the method does not impact the audio transmission between remote participants and a conference and does not allow the local participant to stop sending remote participants’ streams to the conference. Depending on the specified participant in the `participant` parameter, the stopAudio method stops the proper audio transmission:
+   * - When the specified participant is the local participant, stopAudio stops sending local participant’s audio from the local client to the conference.
+   * - When the specified participant is a remote participant, stopAudio stops sending remote participant’s audio from the conference to the local client. This allows the local participant to locally mute remote participants.
+   * @param participant The selected participant. If you wish to not transmit the local participant's audio stream to the conference, provide the local participant's object. If you wish to not receive the specific remote participants' audio streams, provide these remote participants' objects.
+   */
+  public async stopAudio(participant: Participant): Promise<void> {
+    return this._nativeModule.stopAudio(participant);
+  }
+
+  /**
+   * Stops a screen sharing session.
+   */
+  public async stopScreenShare(): Promise<void> {
+    return this._nativeModule.stopScreenShare();
+  }
+
+  /**
+   * Notifies the server to either stop sending the local participant's video stream to the conference or stop sending a remote participant's video stream to the local participant.
+   * @param participant The participant who wants to stop receiving a video stream.
+   */
+  public async stopVideo(participant: Participant): Promise<void> {
+    return this._nativeModule.stopVideo(participant);
+  }
+
+  /**
+   * Updates the participant's conference permissions.
+   * @param participantPermissions The set of participant's conference permissions.
+   */
+  public async updatePermissions(
+    participantPermissions: Array<ParticipantPermissions>
+  ): Promise<void> {
+    return this._nativeModule.updatePermissions(participantPermissions);
   }
 
   /**
@@ -353,27 +373,6 @@ export class ConferenceService {
       streamUpdatedEventUnsubscribe();
       streamRemovedEventUnsubscribe();
     };
-  }
-
-  /**
-   * Starts a screen sharing session.
-   * The ScreenShare with iOS document (https://docs.dolby.io/communications-apis/docs/screenshare-with-ios) describes how to set up screen-share outside the application.
-   * Instead of setting the following properties:
-   * - CommsSDK.shared.appGroup = "YOUR_APP_GROUP"
-   * - CommsSDK.shared.preferredExtension = "YOUR_BROADCAST_EXTENSION_BUNDLE_ID"
-   *  Set up keys in your `Info.plist` file:
-   * - Add a new `DolbyioSdkAppGroupKey` as a string type and enter the group name ("YOUR_APP_GROUP").
-   * - Add a new `DolbyioSdkPreferredExtensionKey` as a string type and enter the broadcast extension bundle ID ("YOUR_BROADCAST_EXTENSION_BUNDLE_ID").
-   */
-  public async startScreenShare(): Promise<void> {
-    return this._nativeModule.startScreenShare();
-  }
-
-  /**
-   * Stops a screen sharing session.
-   */
-  public async stopScreenShare(): Promise<void> {
-    return this._nativeModule.stopScreenShare();
   }
 }
 

--- a/src/services/filePresentation/FilePresentationService.ts
+++ b/src/services/filePresentation/FilePresentationService.ts
@@ -43,37 +43,6 @@ export class FilePresentationService {
   _nativeEvents = new NativeEvents(CommsAPIFilePresentationServiceModule || {});
 
   /**
-   * Stops a file presentation.
-   */
-  public async stop(): Promise<void> {
-    return this._nativeModule.stop();
-  }
-
-  /**
-   * Starts a file presentation.
-   * @param file The converted file that the presenter wants to share during the conference.
-   */
-  public async start(file: FileConverted): Promise<void> {
-    return this._nativeModule.start(file);
-  }
-
-  /**
-   * Provides the URL of a thumbnail that refers to a specific page of the presented file.
-   * @param page The number of the presented page. Files that do not contain any pages, for example, jpg images, require setting the value of this parameter to 0.
-   */
-  public async getThumbnail(page: number): Promise<string> {
-    return this._nativeModule.getThumbnail(page);
-  }
-
-  /**
-   * Informs the service to send the updated page number to conference participants.
-   * @param page The page number that corresponds to the required page.
-   */
-  public async setPage(page: number): Promise<void> {
-    return this._nativeModule.setPage(page);
-  }
-
-  /**
    * Converts a provided file into multiple images. The file is uploaded as FormData.
    *
    * The supported file formats are:
@@ -103,6 +72,37 @@ export class FilePresentationService {
    */
   public async getImage(page: number): Promise<string> {
     return this._nativeModule.getImage(page);
+  }
+
+  /**
+   * Provides the URL of a thumbnail that refers to a specific page of the presented file.
+   * @param page The number of the presented page. Files that do not contain any pages, for example, jpg images, require setting the value of this parameter to 0.
+   */
+  public async getThumbnail(page: number): Promise<string> {
+    return this._nativeModule.getThumbnail(page);
+  }
+
+  /**
+   * Informs the service to send the updated page number to conference participants.
+   * @param page The page number that corresponds to the required page.
+   */
+  public async setPage(page: number): Promise<void> {
+    return this._nativeModule.setPage(page);
+  }
+
+  /**
+   * Starts a file presentation.
+   * @param file The converted file that the presenter wants to share during the conference.
+   */
+  public async start(file: FileConverted): Promise<void> {
+    return this._nativeModule.start(file);
+  }
+
+  /**
+   * Stops a file presentation.
+   */
+  public async stop(): Promise<void> {
+    return this._nativeModule.stop();
   }
 
   /**

--- a/src/services/mediaDevice/MediaDeviceService.ts
+++ b/src/services/mediaDevice/MediaDeviceService.ts
@@ -13,17 +13,17 @@ export class MediaDeviceService {
   _nativeModule = CommsAPIMediaDeviceServiceModule;
 
   /**
-   * Checks whether an application uses the front-facing (true) or back-facing camera (false).
-   */
-  public async isFrontCamera(): Promise<boolean> {
-    return this._nativeModule.isFrontCamera();
-  }
-
-  /**
    * Retrieves the comfort noise level setting for output devices in Dolby Voice conferences.
    */
   public async getComfortNoiseLevel(): Promise<ComfortNoiseLevel> {
     return this._nativeModule.getComfortNoiseLevel();
+  }
+
+  /**
+   * Checks whether an application uses the front-facing (true) or back-facing camera (false).
+   */
+  public async isFrontCamera(): Promise<boolean> {
+    return this._nativeModule.isFrontCamera();
   }
 
   /**

--- a/src/services/notification/NotificationService.ts
+++ b/src/services/notification/NotificationService.ts
@@ -21,6 +21,14 @@ export class NotificationService {
   _nativeEvents = new NativeEvents(CommsAPINotificationServiceModule);
 
   /**
+   * Declines the conference invitation.
+   * @param conference The conference object.
+   */
+  public async decline(conference: Conference): Promise<void> {
+    return this._nativeModule.decline(conference);
+  }
+
+  /**
    * Notifies conference participants about a conference invitation.
    * @param conference The conference object.
    * @param participants Information about the invited application users.
@@ -30,14 +38,6 @@ export class NotificationService {
     participants: ParticipantInvited[]
   ): Promise<void> {
     return this._nativeModule.invite(conference, participants);
-  }
-
-  /**
-   * Declines the conference invitation.
-   * @param conference The conference object.
-   */
-  public async decline(conference: Conference): Promise<void> {
-    return this._nativeModule.decline(conference);
   }
 
   /**

--- a/src/services/session/SessionService.ts
+++ b/src/services/session/SessionService.ts
@@ -14,23 +14,17 @@ export class SessionService {
   _nativeModule = CommsAPISessionServiceModule;
 
   /**
-   * Opens a new session.
-   * @param participantInfo The optional information about the local participant.
-   */
-  public async open(participantInfo: ParticipantInfo = {}): Promise<void> {
-    const { name, avatarUrl, externalId } = participantInfo;
-    return this._nativeModule.open({
-      name,
-      avatarUrl,
-      externalId,
-    });
-  }
-
-  /**
    * Closes the current session.
    */
   public async close(): Promise<void> {
     return this._nativeModule.close();
+  }
+
+  /**
+   * Provides the local participant object that belongs to the current session.
+   */
+  public async getParticipant(): Promise<Participant> {
+    return this._nativeModule.getParticipant();
   }
 
   /**
@@ -41,10 +35,16 @@ export class SessionService {
   }
 
   /**
-   * Provides the local participant object that belongs to the current session.
+   * Opens a new session.
+   * @param participantInfo The optional information about the local participant.
    */
-  public async getParticipant(): Promise<Participant> {
-    return this._nativeModule.getParticipant();
+  public async open(participantInfo: ParticipantInfo = {}): Promise<void> {
+    const { name, avatarUrl, externalId } = participantInfo;
+    return this._nativeModule.open({
+      name,
+      avatarUrl,
+      externalId,
+    });
   }
 }
 

--- a/src/services/videoPresentation/VideoPresentationService.ts
+++ b/src/services/videoPresentation/VideoPresentationService.ts
@@ -34,6 +34,13 @@ export class VideoPresentationService {
   );
 
   /**
+   * Returns information about the current video presentation.
+   */
+  public current(): Promise<VideoPresentation | null> {
+    return this._nativeModule.current();
+  }
+
+  /**
    * Pauses a video presentation.
    * @param timestamp The timestamp that informs when the video needs to be paused, in milliseconds.
    */
@@ -46,20 +53,6 @@ export class VideoPresentationService {
    */
   public play(): Promise<void> {
     return this._nativeModule.play();
-  }
-
-  /**
-   * Returns information about the current video presentation.
-   */
-  public current(): Promise<VideoPresentation | null> {
-    return this._nativeModule.current();
-  }
-
-  /**
-   * Provides the current state of a video presentation.
-   */
-  public state(): Promise<VideoPresentationState> {
-    return this._nativeModule.state();
   }
 
   /**
@@ -76,6 +69,13 @@ export class VideoPresentationService {
    */
   public start(url: string): Promise<void> {
     return this._nativeModule.start(url);
+  }
+
+  /**
+   * Provides the current state of a video presentation.
+   */
+  public state(): Promise<VideoPresentationState> {
+    return this._nativeModule.state();
   }
 
   /**


### PR DESCRIPTION
Apart from doc conversion script changes and improvements, this PR also changes order of methods in our files, because the requirement was to have event handlers separate from rest of methods (to be able to group it on dolby documentation website).
The documentation sorting algorithm is set now to `source-order`, which means documentation order will reflect order of methods we define in our classes. Due to that I had to reorganise methods alphabetically (no changes to contents of methods were done).